### PR TITLE
Queue policies

### DIFF
--- a/ndingestproj/bossingestproj.py
+++ b/ndingestproj/bossingestproj.py
@@ -20,31 +20,26 @@ from ndingestproj.ingestproj import IngestProj
 class BossIngestProj(IngestProj):
 
     def __init__(
-        self, collection_name, channel_name, 
-        resolution, experiment_name=None, domain_name='test.boss.io'):
+        self, collection_name, experiment_name, channel_name, resolution, 
+        job_id, domain_name):
         """Constructor.
 
         Collection name and experiment name are joined with an & to form the
-        project name.  If experiment name isn't provided, the project_name is
-        '{}&{}'.format(collection_name, collection_name).  
-        
-        Both experiment_name and domain_name are optional to maintain 
-        compatibility with Neurodata.
+        project name.  
 
         Args:
             collection_name (string): Collection name.
+            experiment_name (string): Experiment name.
             channel_name (string): Channel name.
             resolution (string): '0' indicates native resolution.
-            experiment_name (optional[string]): Defaults to None.
-            domain_name (optional[string]): Defaults to 'test.boss.io'.  Domain ndingest running in.  Note, periods will be replaced with dashes for compatibility with AWS.
+            job_id (string): Id for this ingest job.
+            domain_name (string): Domain ndingest running in.  Note, periods will be replaced with dashes for compatibility with AWS.
         """
         self._domain_name = domain_name.replace('.', '-')
-        if experiment_name is not None:
-            self._project_name = collection_name + '&' + experiment_name
-        else:
-            self._project_name = collection_name + '&' + collection_name
+        self._project_name = collection_name + '&' + experiment_name
         self._channel_name = channel_name
         self._resolution = resolution
+        self._job_id = job_id
 
     @classmethod
     def fromTileKey(cls, tile_key):
@@ -58,6 +53,8 @@ class BossIngestProj(IngestProj):
   
     @property
     def project_name(self):
+        """For the Boss, this is the collection name and the experiment name, combined.
+        """
         return self._project_name
   
     @project_name.setter
@@ -83,4 +80,8 @@ class BossIngestProj(IngestProj):
     @property
     def domain(self):
         return self._domain_name
+
+    @property
+    def job_id(self):
+        return self._job_id
 

--- a/ndqueue/cleanupqueue.py
+++ b/ndqueue/cleanupqueue.py
@@ -36,11 +36,11 @@ class CleanupQueue(NDQueue):
     
   @staticmethod 
   def generateBossQueueName(nd_proj):
-    return NotImplemented
+    return '{}-delete-{}'.format(nd_proj.domain, nd_proj.job_id)
 
   @staticmethod
   def createQueue(nd_proj, region_name=settings.REGION_NAME, endpoint_url=None):
-    """Create the upload queue"""
+    """Create the cleanup queue"""
     
     # creating the resource
     queue_name = CleanupQueue.generateQueueName(nd_proj)

--- a/ndqueue/ingestqueue.py
+++ b/ndqueue/ingestqueue.py
@@ -35,7 +35,7 @@ class IngestQueue(NDQueue):
     
   @staticmethod 
   def generateBossQueueName(nd_proj):
-    return NotImplemented
+    return '{}-ingest-{}'.format(nd_proj.domain, nd_proj.job_id)
 
   @staticmethod
   def createQueue(nd_proj, region_name=settings.REGION_NAME, endpoint_url=None):

--- a/ndqueue/ndqueue.py
+++ b/ndqueue/ndqueue.py
@@ -48,7 +48,7 @@ class NDQueue(object):
   def getNameGenerator(cls):
     if settings.PROJECT_NAME == 'Neurodata':
       return cls.generateNeurodataQueueName
-    elif settings.PROJECT_NAME == 'Bpss':
+    elif settings.PROJECT_NAME == 'Boss':
       return cls.generateBossQueueName
     else:
       print ("Unknown Project Name {}".format(settings.PROJECT_NAME))

--- a/ndqueue/ndqueue.py
+++ b/ndqueue/ndqueue.py
@@ -19,12 +19,17 @@ settings = Settings.load()
 from abc import abstractmethod
 import boto3
 import botocore
+import json
 
 class NDQueue(object):
 
   def __init__(self, queue_name, region_name=settings.REGION_NAME, endpoint_url=None):
     """Create resource for the queue"""
     
+    self.region_name = region_name
+    self.endpoint_url = endpoint_url
+    self.queue_name = queue_name
+
     sqs = boto3.resource('sqs', region_name=region_name, endpoint_url=endpoint_url, aws_access_key_id=settings.AWS_ACCESS_KEY_ID, aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
     try:
       self.queue = sqs.get_queue_by_name(
@@ -53,6 +58,102 @@ class NDQueue(object):
     else:
       print ("Unknown Project Name {}".format(settings.PROJECT_NAME))
   
+  def createPolicy(self, policy, name=None, description=''):
+    """Create a policy for this queue.
+
+    The policy parameter defines actions allowed on the queue.  This policy 
+    must be assigned to an AWS user to give access to the queue.  Simple 
+    policies can be represented with a single IAM statement.
+
+    Sample IAM statement dictionary: 
+        { 'Sid': 'Receive Access Statement',
+          'Effect': 'Allow',
+          'Action': ['sqs:ReceiveMessage'] }
+
+    Args:
+        policy (list(dict)): List of IAM statements. 
+        name (optional[string]): Custom name for this policy.  By default, the queue's name is used.
+        description (optional[string]): Description of policy.
+
+    Returns:
+        (iam.Policy)
+    """
+    iam = boto3.resource(
+        'iam',
+        region_name=self.region_name, endpoint_url=self.endpoint_url, 
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID, 
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+
+    full_policy = { 'Version': '2012-10-17', 'Statement': policy }
+
+    # Specify this queue as the resource for each policy statement.
+    for statement in policy:
+        statement['Resource'] = self.queue.attributes['QueueArn']
+
+    if name is None:
+        full_policy['Id'] = self.queue_name
+    else:
+        full_policy['Id'] = name
+
+    doc = json.dumps(full_policy)
+    return iam.create_policy(
+        PolicyName=full_policy['Id'],
+        PolicyDocument=json.dumps(full_policy),
+        Path=settings.IAM_POLICY_PATH,
+        Description=description)
+
+
+  def deletePolicy(self, name=None):
+    """Deletes the queue's policy.
+
+    Args:
+        name (optional[string]): Defaults to name of queue.
+    """
+
+    if name is not None:
+        policy_name = name
+    else:
+        policy_name = self.queue_name
+
+    arn = self.getPolicyArn(policy_name)
+    if arn is None:
+        raise RuntimeError('Policy {} could not be found.'.format(policy_name))
+
+    iam = boto3.resource(
+        'iam',
+        region_name=self.region_name, endpoint_url=self.endpoint_url, 
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID, 
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+
+    policy = iam.Policy(arn)
+    policy.delete()
+
+
+  def getPolicyArn(self, name):
+    """Find the named policy and return its Arn.
+
+    Only user created policies with a path prefix as defined in settings.ini are retrieved.  
+    Global AWS policies are ignored.
+
+    Args:
+        name (string): Name of policy.
+
+    Returns:
+        (string|None): None if policy cannot be found.
+    """
+    iam = boto3.resource(
+        'iam',
+        region_name=self.region_name, endpoint_url=self.endpoint_url, 
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID, 
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+
+    for policy in iam.policies.all():
+        if policy.policy_name == name:
+            return policy.arn
+
+    return None
+
+
   def sendMessage(self, message_body, delay_seconds=0):
     """Send message to the queue"""
     try:

--- a/ndqueue/uploadqueue.py
+++ b/ndqueue/uploadqueue.py
@@ -37,7 +37,7 @@ class UploadQueue(NDQueue):
     
   @staticmethod 
   def generateBossQueueName(nd_proj):
-    return NotImplemented
+    return '{}-upload-{}'.format(nd_proj.domain, nd_proj.job_id)
 
   @staticmethod
   def createQueue(nd_proj, region_name=settings.REGION_NAME, endpoint_url=None):

--- a/settings/bosssettings.py
+++ b/settings/bosssettings.py
@@ -98,3 +98,11 @@ class BossSettings(Settings):
     @property
     def UPLOAD_TASK_DEADLETTER_QUEUE(self):
         return self.parser.get('aws', 'upload_task_deadletter_queue_url')
+
+    @property
+    def IAM_POLICY_PATH(self):
+        """Path to use when creating an IAM policy.
+
+        Must return '/' or a string beginning and ending with '/'.
+        """
+        return '/ingest/'

--- a/settings/settings.py
+++ b/settings/settings.py
@@ -110,3 +110,12 @@ class Settings(object):
   @abstractmethod
   def SUPER_CUBOID_SIZE(self):
     return NotImplemented
+
+  @property
+  @abstractmethod
+  def IAM_POLICY_PATH(self):
+    """Path to use when creating an IAM policy.
+
+    Must return '/' or a string beginning and ending with '/'.
+    """
+    return NotImplemented

--- a/test/test_bossingestproj.py
+++ b/test/test_bossingestproj.py
@@ -17,19 +17,10 @@ import six
 from ndingestproj.bossingestproj import BossIngestProj
 
 class TestBossIngestProj(unittest.TestCase):
-    def test_generateProjectInfo(self):
-        prj = BossIngestProj('col1', 'chanA', '0', 'exp1', 'test.boss.io')
-        expected = ['test-boss-io', 'col1&exp1', 'chanA', '0']
-        six.assertCountEqual(self, expected, prj.generateProjectInfo())
-
     def test_project_name(self):
-        prj = BossIngestProj('col1', 'chanA', '0', 'exp1', 'test.boss.io')
+        """Project name should be collection name & experiment name."""
+        prj = BossIngestProj('col1', 'exp1', 'chanA', '0', '123', 'test.boss.io')
         expected = 'col1&exp1'
-        self.assertEqual(expected, prj.project_name)
-
-    def test_project_name_defaults(self):
-        prj = BossIngestProj('col1', 'chanA', '0')
-        expected = 'col1&col1'
         self.assertEqual(expected, prj.project_name)
 
 if __name__ == '__main__':

--- a/test/test_cleanupqueue.py
+++ b/test/test_cleanupqueue.py
@@ -22,19 +22,26 @@ import pytest
 from ndqueue.cleanupqueue import CleanupQueue
 from ndingestproj.ingestproj import IngestProj
 ProjClass = IngestProj.load()
-nd_proj = ProjClass('kasthuri11', 'image', '0')
+if settings.PROJECT_NAME == 'Boss':
+    nd_proj = ProjClass('testCol', 'kasthuri11', 'image', 0, 12, 'test.boss.io')
+else:
+    nd_proj = ProjClass('kasthuri11', 'image', '0')
 
 
 class Test_Cleanup_Queue():
 
   def setup_class(self):
     """Setup class parameters"""
-    CleanupQueue.createQueue(nd_proj, endpoint_url=settings.SQS_ENDPOINT)
-    self.cleanup_queue = CleanupQueue(nd_proj, endpoint_url=settings.SQS_ENDPOINT)
+    if 'SQS_ENDPOINT' in dir(settings):
+      self.endpoint_url = settings.SQS_ENDPOINT
+    else:
+      self.endpoint_url = None
+    CleanupQueue.createQueue(nd_proj, endpoint_url=self.endpoint_url)
+    self.cleanup_queue = CleanupQueue(nd_proj, endpoint_url=self.endpoint_url)
   
   def teardown_class(self):
     """Teardown parameters"""
-    CleanupQueue.deleteQueue(nd_proj, endpoint_url=settings.SQS_ENDPOINT)
+    CleanupQueue.deleteQueue(nd_proj, endpoint_url=self.endpoint_url)
 
   def test_Message(self):
     """Testing the upload queue"""

--- a/test/test_ingestqueue.py
+++ b/test/test_ingestqueue.py
@@ -22,7 +22,10 @@ import pytest
 from ndqueue.ingestqueue import IngestQueue
 from ndingestproj.ingestproj import IngestProj
 ProjClass = IngestProj.load()
-nd_proj = ProjClass('kasthuri11', 'image', '0')
+if settings.PROJECT_NAME == 'Boss':
+    nd_proj = ProjClass('testCol', 'kasthuri11', 'image', 0, 12, 'test.boss.io')
+else:
+    nd_proj = ProjClass('kasthuri11', 'image', '0')
 
 
 class Test_Ingest_Queue():

--- a/test/test_uploadqueue.py
+++ b/test/test_uploadqueue.py
@@ -24,7 +24,10 @@ from ndqueue.serializer import Serializer
 serializer = Serializer.load()
 from ndingestproj.ingestproj import IngestProj
 ProjClass = IngestProj.load()
-nd_proj = ProjClass('kasthuri11', 'image', '0')
+if settings.PROJECT_NAME == 'Boss':
+    nd_proj = ProjClass('testCol', 'kasthuri11', 'image', 0, 12, 'test.boss.io')
+else:
+    nd_proj = ProjClass('kasthuri11', 'image', '0')
 
 
 class Test_UploadQueue():


### PR DESCRIPTION
Added NDQueue.createPolicy() and NDQueue.deletePolicy().
Both are dependent on a new Settings property: IAM_POLICY_PATH.

Tests added to test_uploadqueue.py. These tests may need to be skipped if not running with AWS.