### PR TITLE
Dead letter queue support and tile bucket IAM policy support

### DIFF
--- a/ndbucket/tilebucket.py
+++ b/ndbucket/tilebucket.py
@@ -17,10 +17,10 @@ from __future__ import print_function
 from __future__ import absolute_import
 from settings.settings import Settings
 settings = Settings.load()
-import hashlib
 import boto3
 import botocore
 import hashlib
+import json
 from util.util import Util
 UtilClass = Util.load()
 
@@ -29,6 +29,8 @@ class TileBucket:
   def __init__(self, project_name, region_name=settings.REGION_NAME, endpoint_url=None):
     """Create resource for the upload queue"""
     
+    self.region_name = region_name
+    self.endpoint_url = endpoint_url
     bucket_name = TileBucket.getBucketName()
     self.project_name = project_name
     self.s3 = boto3.resource(
@@ -89,6 +91,131 @@ class TileBucket:
   def decodeObjectKey(object_key):
     """Decode an object key"""
     return object_key.split('&')
+
+  def createPolicy(self, policy, name, folder=None, description=''):
+    """Create an IAM policy for the bucket.
+
+    The policy parameter defines actions allowed on the bucket.  This policy 
+    must be assigned to an AWS user to give access to the bucket.  Simple 
+    policies can be represented with a single IAM statement.  The bucket's ARN
+    will be added to each statment (as the Resource the statement applies to).
+
+    If folder is provided, each IAM statement is targeted at that folder.  
+    For example, if folder='/foo/bar' and the bucket is named my_tile_bucket,
+    this is added to each statement dictionary:
+        'Resource':'arn:aws:s3:::my_tile_bucket/foo/bar/*'
+
+
+    Sample IAM statement dictionary: 
+        { 'Sid': 'Receive Access Statement',
+          'Effect': 'Allow',
+          'Action': ['s3:PutObject'] }
+
+    Args:
+        policy (list(dict)): List of IAM statements. 
+        name (string): Name for this policy.
+        folder (optional[string]): Optionally target each statement to a specific folder.
+        description (optional[string]): Description of policy.
+
+    Returns:
+        (iam.Policy)
+    """
+    iam = boto3.resource(
+        'iam',
+        region_name=self.region_name, endpoint_url=self.endpoint_url, 
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID, 
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+
+    full_policy = { 'Version': '2012-10-17', 'Statement': policy }
+
+    arn = TileBucket.buildArn(self.bucket.name, folder)
+
+    # Specify this bucket as the resource for each policy statement.
+    for statement in policy:
+        statement['Resource'] = arn
+
+    full_policy['Id'] = name
+
+    doc = json.dumps(full_policy)
+    return iam.create_policy(
+        PolicyName=full_policy['Id'],
+        PolicyDocument=json.dumps(full_policy),
+        Path=settings.IAM_POLICY_PATH,
+        Description=description)
+
+
+  @staticmethod
+  def buildArn(bucket_name, folder=None):
+    """Build an S3 ARN for use in an IAM policy.
+
+    Example: arn:aws:s3:::my_bucket/some/folder/*
+
+    Args:
+      bucket_name (string): Name of bucket.
+      folder (optional[string]): Optional folder to apply IAM policy to.
+
+    Returns:
+      (string)
+    """
+    arn = 'arn:aws:s3:::' + bucket_name
+    if folder is not None:
+        if folder[0] != '/':
+            arn += '/'
+        arn += folder
+        if not folder.endswith('/'):
+            arn += '/'
+        arn += '*'
+    else:
+        arn += '/*'
+
+    return arn
+
+
+  def deletePolicy(self, name):
+    """Deletes the queue's policy.
+
+    Args:
+        name (string): Policy name.
+    """
+
+    arn = self.getPolicyArn(name)
+    if arn is None:
+        raise RuntimeError('Policy {} could not be found.'.format(name))
+
+    iam = boto3.resource(
+        'iam',
+        region_name=self.region_name, endpoint_url=self.endpoint_url, 
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID, 
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+
+    policy = iam.Policy(arn)
+    policy.delete()
+
+
+  def getPolicyArn(self, name):
+    """Find the named policy and return its Arn.
+
+    Only user created policies with a path prefix as defined in settings.ini are retrieved.  
+    Global AWS policies are ignored.
+
+    Args:
+        name (string): Name of policy.
+
+    Returns:
+        (string|None): None if policy cannot be found.
+    """
+    iam = boto3.resource(
+        'iam',
+        region_name=self.region_name, endpoint_url=self.endpoint_url, 
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID, 
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+
+    for policy in iam.policies.all():
+        if policy.policy_name == name:
+            return policy.arn
+
+    return None
+
 
   def putObject(self, tile_handle, channel_name, resolution, x_tile, y_tile, z_tile, message_id, receipt_handle, time=0):
     """Put object in the upload bucket"""
@@ -165,4 +292,3 @@ class TileBucket:
     except Exception as e:
       print (e)
       raise
-

--- a/ndqueue/cleanupqueue.py
+++ b/ndqueue/cleanupqueue.py
@@ -62,24 +62,21 @@ class CleanupQueue(NDQueue):
 
 
   @staticmethod  
-  def deleteQueue(nd_proj, region_name=settings.REGION_NAME, endpoint_url=None):
-    """Delete the upload queue"""
+  def deleteQueue(nd_proj, region_name=settings.REGION_NAME, endpoint_url=None, delete_deadletter_queue=False):
+    """Delete the cleanup queue.
+    
+    Also delete the dead letter queue if delete_deadletter_queue is true.
+
+    Args:
+        nd_proj (IngestProj): Project settings used to generate queue's name.
+        region_name (optional[string]): AWS region queue lives in.  Extracted from settings.ini if not provided.
+        endpoint_url (optional[string]): Provide if using a mock or fake Boto3 service.
+        delete_deadletter_queue (optional[bool]): Also delete the dead letter queue.  Defaults to False.
+    """
 
     # creating the resource
     queue_name = CleanupQueue.generateQueueName(nd_proj)
-    sqs = boto3.resource('sqs', region_name=region_name, endpoint_url=endpoint_url, aws_access_key_id=settings.AWS_ACCESS_KEY_ID, aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
-    
-    try:
-      # try fetching queue first
-      queue = sqs.get_queue_by_name(
-          QueueName = queue_name
-      )
-      # deleting the queue
-      response = queue.delete()
-      return response
-    except Exception as e:
-      print (e)
-      raise
+    NDQueue.deleteQueueByName(queue_name, region_name, endpoint_url, delete_deadletter_queue)
 
 
   @staticmethod

--- a/ndqueue/ingestqueue.py
+++ b/ndqueue/ingestqueue.py
@@ -61,23 +61,21 @@ class IngestQueue(NDQueue):
 
 
   @staticmethod  
-  def deleteQueue(nd_proj, region_name=settings.REGION_NAME, endpoint_url=None):
-    """Delete the upload queue"""
+  def deleteQueue(nd_proj, region_name=settings.REGION_NAME, endpoint_url=None, delete_deadletter_queue=False):
+    """Delete the ingest queue.
+    
+    Also delete the dead letter queue if delete_deadletter_queue is true.
+
+    Args:
+        nd_proj (IngestProj): Project settings used to generate queue's name.
+        region_name (optional[string]): AWS region queue lives in.  Extracted from settings.ini if not provided.
+        endpoint_url (optional[string]): Provide if using a mock or fake Boto3 service.
+        delete_deadletter_queue (optional[bool]): Also delete the dead letter queue.  Defaults to False.
+    """
 
     # creating the resource
     queue_name = IngestQueue.generateQueueName(nd_proj)
-    sqs = boto3.resource('sqs', region_name=region_name, endpoint_url=endpoint_url, aws_access_key_id=settings.AWS_ACCESS_KEY_ID, aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
-    
-    try:
-      # try fetching queue first
-      queue = sqs.get_queue_by_name(
-          QueueName = queue_name
-      )
-      # deleting the queue
-      response = queue.delete()
-    except Exception as e:
-      print (e)
-      raise
+    NDQueue.deleteQueueByName(queue_name, region_name, endpoint_url, delete_deadletter_queue)
 
 
   @staticmethod

--- a/ndqueue/ndqueue.py
+++ b/ndqueue/ndqueue.py
@@ -58,7 +58,135 @@ class NDQueue(object):
       return cls.generateBossQueueName
     else:
       print ("Unknown Project Name {}".format(settings.PROJECT_NAME))
-  
+
+
+  @staticmethod
+  def deleteQueueByName(name, region_name=settings.REGION_NAME, endpoint_url=None, delete_deadletter_queue=False):
+    """Delete the named queue.
+    
+    Also delete the dead letter queue if delete_deadletter_queue is true.
+
+    Args:
+        name (string): Name of queue to delete.
+        region_name (optional[string]): AWS region queue lives in.  Extracted from settings.ini if not provided.
+        endpoint_url (optional[string]): Provide if using a mock or fake Boto3 service.
+        delete_deadletter_queue (optional[bool]): Also delete the dead letter queue.  Defaults to False.
+    """
+
+    sqs = boto3.resource('sqs', region_name=region_name, endpoint_url=endpoint_url, aws_access_key_id=settings.AWS_ACCESS_KEY_ID, aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+    
+    try:
+      # try fetching queue first
+      queue = sqs.get_queue_by_name(QueueName=name)
+
+      if delete_deadletter_queue:
+          NDQueue.deleteDeadLetterQueue(sqs, queue)
+
+      # delete the queue
+      queue.delete()
+    except Exception as e:
+      print (e)
+      raise
+
+
+  def addDeadLetterQueue(self, max_receive_count, queue_arn=None):
+      """Sets the dead letter queue.
+
+      A dead letter queue will be created if queue_arn is not supplied.  If
+      creating, the dead letter queue will have the same name as the queue it
+      supports, but with '_dead_letter' appended.
+
+      Args:
+        max_receive_count (int): Max times a message may be received before sending to the dead letter queue.
+        queue_arn (optional[string]): ARN of existing queue to use for the dead letter queue.
+
+      Return:
+        (SQS.Queue): The dead letter queue.
+      """
+
+      sqs = boto3.resource(
+          'sqs',
+          region_name=self.region_name, endpoint_url=self.endpoint_url, 
+          aws_access_key_id=settings.AWS_ACCESS_KEY_ID, 
+          aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+
+      if queue_arn is not None:
+          arn = queue_arn
+          queue = NDQueue.findQueueByArn(sqs, arn)
+          if queue is None:
+              msg = 'Queue {} not found.'.format(arn)
+              print(msg)
+              raise RuntimeError(msg)
+      else:
+          # Create dead letter queue.
+          name = self.queue_name + '_dead_letter'
+          sqs = boto3.resource(
+              'sqs',
+              region_name=self.region_name, endpoint_url=self.endpoint_url, 
+              aws_access_key_id=settings.AWS_ACCESS_KEY_ID, 
+              aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+          try:
+              queue = sqs.create_queue(
+                  QueueName=name,
+                  Attributes = {
+                      'DelaySeconds': '0',
+                      'MaximumMessageSize': '262144'
+                  }
+              )
+              arn = queue.attributes['QueueArn']
+          except Exception as e:
+              print(e)
+              raise
+
+      policy = {'maxReceiveCount': max_receive_count, 'deadLetterTargetArn': arn}
+
+      # Set dead letter policy on the queue.
+      self.queue.set_attributes(Attributes={'RedrivePolicy': json.dumps(policy)})
+
+      # Return the dead letter queue.
+      return queue
+
+
+  @staticmethod
+  def deleteDeadLetterQueue(sqs, queue):
+      """Delete the dead letter queue associated with the given queue.
+
+      Args:
+        sqs (SQS.ServiceResource): Live resource used for queue operations.
+        queue (SQS.Queue): The queue that "owns" the dead letter queue.
+      """
+
+      if 'RedrivePolicy' not in queue.attributes:
+          print('Delete failed - queue {} does not have a dead letter queue.'.format(queue.url))
+          return
+
+      policy = json.loads(queue.attributes['RedrivePolicy'])
+      arn = policy['deadLetterTargetArn']
+
+      dlet_queue = NDQueue.findQueueByArn(sqs, arn)
+      if dlet_queue is None:
+          print('Delete failed for {} - not found.'.format(arn))
+          return
+
+      dlet_queue.delete()
+
+
+  @staticmethod
+  def findQueueByArn(sqs, arn):
+      """Find a queue by its ARN.
+
+      Args:
+        sqs (SQS.ServiceResource): Live resource used for queue operations.
+        arn (string): ARN of queue.
+
+      Returns:
+        (SQS.Queue|None): None if queue not found.
+      """
+
+      (_, name) = arn.rsplit(':', 1)
+      return sqs.get_queue_by_name(QueueName=name)
+
+
   def createPolicy(self, policy, name=None, description=''):
     """Create a policy for this queue.
 

--- a/ndqueue/ndqueue.py
+++ b/ndqueue/ndqueue.py
@@ -1,4 +1,5 @@
 # Copyright 2014 NeuroData (http://neurodata.io)
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ndqueue/uploadqueue.py
+++ b/ndqueue/uploadqueue.py
@@ -63,24 +63,22 @@ class UploadQueue(NDQueue):
 
 
   @staticmethod  
-  def deleteQueue(nd_proj, region_name=settings.REGION_NAME, endpoint_url=None):
-    """Delete the upload queue"""
+  def deleteQueue(nd_proj, region_name=settings.REGION_NAME, endpoint_url=None, delete_deadletter_queue=False):
+    """Delete the upload queue.
+    
+    Also delete the dead letter queue if delete_deadletter_queue is true.
+
+    Args:
+        nd_proj (IngestProj): Project settings used to generate queue's name.
+        region_name (optional[string]): AWS region queue lives in.  Extracted from settings.ini if not provided.
+        endpoint_url (optional[string]): Provide if using a mock or fake Boto3 service.
+        delete_deadletter_queue (optional[bool]): Also delete the dead letter queue.  Defaults to False.
+    """
 
     # creating the resource
     queue_name = UploadQueue.generateQueueName(nd_proj)
-    sqs = boto3.resource('sqs', region_name=region_name, endpoint_url=endpoint_url, aws_access_key_id=settings.AWS_ACCESS_KEY_ID, aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
-    
-    try:
-      # try fetching queue first
-      queue = sqs.get_queue_by_name(
-          QueueName = queue_name
-      )
-      # deleting the queue
-      response = queue.delete()
-      return response
-    except Exception as e:
-      print (e)
-      raise
+    NDQueue.deleteQueueByName(queue_name, region_name, endpoint_url, delete_deadletter_queue)
+
 
   @staticmethod
   def generateQueueName(nd_proj):

--- a/test/test_cuboidbucket.py
+++ b/test/test_cuboidbucket.py
@@ -27,7 +27,10 @@ from ndbucket.cuboidbucket import CuboidBucket
 from ndingestproj.ingestproj import IngestProj
 import pytest
 ProjClass = IngestProj.load()
-nd_proj = ProjClass('kasthuri11', 'image', '0')
+if settings.PROJECT_NAME == 'Boss':
+    nd_proj = ProjClass('testCol', 'kasthuri11', 'image', 0, 124, 'test.boss.io')
+else:
+    nd_proj = ProjClass('kasthuri11', 'image', '0')
 
 
 class Test_Cuboid_Bucket():

--- a/test/test_deadletter_queue.py
+++ b/test/test_deadletter_queue.py
@@ -1,0 +1,166 @@
+# Copyright 2014 NeuroData (http://neurodata.io)
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import print_function
+import sys
+sys.path.append('..')
+from settings.settings import Settings
+settings = Settings.load()
+import json
+from ndqueue.ndqueue import NDQueue
+from ndqueue.uploadqueue import UploadQueue
+from ndqueue.serializer import Serializer
+serializer = Serializer.load()
+from ndingestproj.ingestproj import IngestProj
+ProjClass = IngestProj.load()
+from random import randint
+import unittest
+import boto3
+import botocore
+import time
+
+class Test_test_deadletter_queue(unittest.TestCase):
+    def setUp(self):
+        if 'SQS_ENDPOINT' in dir(settings):
+          self.endpoint_url = settings.SQS_ENDPOINT
+        else:
+          self.endpoint_url = None
+
+        self.upload_queue = None
+        self.nd_proj = self.generate_proj()
+
+    def tearDown(self):
+        if self.upload_queue is not None:
+            self.upload_queue.queue.delete()
+
+    def generate_proj(self):
+        """Add some randomness to the project.
+       
+        Queue names must be different between tests because a deleted queue
+        cannot be recreated with the same name until 60s has elapsed.
+        """
+
+        num = randint(100, 999)
+
+        if settings.PROJECT_NAME == 'Boss':
+            job_id = num
+            nd_proj = ProjClass('testCol', 'kasthuri11', 'image', 0, job_id, 'test.boss.io')
+        else:
+            channel = 'image{}'.format(num)
+            nd_proj = ProjClass('kasthuri11', channel, '0')
+
+        return nd_proj
+
+
+    def test_create_queue_with_default_name(self):
+        # Create upload queue.
+        UploadQueue.createQueue(self.nd_proj, endpoint_url=self.endpoint_url)
+        self.upload_queue = UploadQueue(self.nd_proj, endpoint_url=self.endpoint_url)
+
+        # Create dead letter queue with default name.
+        exp_max_receives = 4
+        dl_queue = self.upload_queue.addDeadLetterQueue(exp_max_receives)
+
+        exp_name = self.upload_queue.queue_name + '_dead_letter'
+        exp_arn = dl_queue.attributes['QueueArn']
+
+        try:
+            policy = json.loads(
+                self.upload_queue.queue.attributes['RedrivePolicy'])
+            self.assertEqual(exp_max_receives, policy['maxReceiveCount'])
+            self.assertEqual(exp_arn, policy['deadLetterTargetArn'])
+            # Confirm dead letter queue named correctly by looking at the end 
+            # of its ARN.
+            self.assertTrue(dl_queue.attributes['QueueArn'].endswith(exp_name))
+        finally:
+            dl_queue.delete()
+
+
+    def test_add_existing_queue_as_dead_letter_queue(self):
+        # Create existing queue for dead letter queue.
+        sqs = boto3.resource(
+            'sqs',
+            region_name=settings.REGION_NAME, endpoint_url=self.endpoint_url, 
+            aws_access_key_id=settings.AWS_ACCESS_KEY_ID, 
+            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+        queue_name = 'deadletter_test_{}'.format(randint(100, 999))
+        existing_queue = sqs.create_queue(
+            QueueName=queue_name,
+            Attributes={
+                'DelaySeconds': '0',
+                'MaximumMessageSize': '262144'
+            }
+        )
+
+        exp_arn = existing_queue.attributes['QueueArn']
+
+        try:
+            # Create upload queue.
+            UploadQueue.createQueue(self.nd_proj, endpoint_url=self.endpoint_url)
+            self.upload_queue = UploadQueue(self.nd_proj, endpoint_url=self.endpoint_url)
+
+            # Attach the dead letter queue to it.
+            exp_max_receives = 5
+            dl_queue = self.upload_queue.addDeadLetterQueue(
+                exp_max_receives, exp_arn)
+
+            # Confirm policy settings.
+            policy = json.loads(
+                self.upload_queue.queue.attributes['RedrivePolicy'])
+            self.assertEqual(exp_max_receives, policy['maxReceiveCount'])
+            self.assertEqual(exp_arn, policy['deadLetterTargetArn'])
+
+            # Confirm dead letter queue is the one created at the beginning 
+            # of test.
+            self.assertEqual(existing_queue.url, dl_queue.url)
+        finally:
+            existing_queue.delete()
+
+
+    def test_delete_dead_letter_queue(self):
+        # Create existing queue for dead letter queue.
+        sqs = boto3.resource(
+            'sqs',
+            region_name=settings.REGION_NAME, endpoint_url=self.endpoint_url, 
+            aws_access_key_id=settings.AWS_ACCESS_KEY_ID, 
+            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+        queue_name = 'deadletter_test_{}'.format(randint(100, 999))
+        existing_queue = sqs.create_queue(
+            QueueName=queue_name,
+            Attributes={
+                'DelaySeconds': '0',
+                'MaximumMessageSize': '262144'
+            }
+        )
+
+        # Create upload queue. 
+        arn = existing_queue.attributes['QueueArn']
+        UploadQueue.createQueue(self.nd_proj, endpoint_url=self.endpoint_url)
+        self.upload_queue = UploadQueue(self.nd_proj, endpoint_url=self.endpoint_url)
+
+        # Attach the dead letter queue to it.
+        dl_queue = self.upload_queue.addDeadLetterQueue(2, arn)
+
+        # Invoke the delete method.
+        NDQueue.deleteDeadLetterQueue(sqs, self.upload_queue.queue)
+
+        # Confirm deletion.
+        with self.assertRaises(botocore.exceptions.ClientError):
+            sqs.get_queue_by_name(QueueName=queue_name)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_tilebucket.py
+++ b/test/test_tilebucket.py
@@ -22,7 +22,10 @@ from io import BytesIO
 from ndbucket.tilebucket import TileBucket
 from ndingestproj.ingestproj import IngestProj
 ProjClass = IngestProj.load()
-nd_proj = ProjClass('kasthuri11', 'image', '0')
+if settings.PROJECT_NAME == 'Boss':
+    nd_proj = ProjClass('testCol', 'kasthuri11', 'image', 0, 124, 'test.boss.io')
+else:
+    nd_proj = ProjClass('kasthuri11', 'image', '0')
 
 
 class Test_Upload_Bucket():

--- a/test/test_tilebucket.py
+++ b/test/test_tilebucket.py
@@ -1,4 +1,5 @@
 # Copyright 2014 NeuroData (http://neurodata.io)
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,3 +75,109 @@ class Test_Upload_Bucket():
       assert( object_receipt_handle == receipt_handle )
       # delete the object
       response = self.tile_bucket.deleteObject(object_key)
+
+
+  def test_buildArn_no_folder(self):
+    """Test buildArn with folder's default value."""
+
+    expected = 'arn:aws:s3:::my_bucket/*'
+    actual = TileBucket.buildArn('my_bucket')
+    assert(expected == actual)
+    
+
+  def test_buildArn_with_folder_no_slashes(self):
+    """Test buildArn with a folder."""
+
+    expected = 'arn:aws:s3:::my_bucket/some/folder/*'
+    actual = TileBucket.buildArn('my_bucket', 'some/folder')
+    assert(expected == actual)
+    
+
+  def test_buildArn_with_folder_with_slashes(self):
+    """Test buildArn with folder with slashes at beginning and end."""
+
+    expected = 'arn:aws:s3:::my_bucket/some/folder/*'
+    actual = TileBucket.buildArn('my_bucket', '/some/folder/')
+    assert(expected == actual)
+
+
+  def test_createPolicy(self):
+    """Test policy creation"""
+
+    statements = [{
+      'Sid': 'WriteAccess',
+      'Effect': 'Allow',
+      'Action': ['s3:PutObject'] 
+    }]
+
+    expName = 'ndingest_test_tile_bucket_policy'
+    expDesc = 'Test policy creation'
+
+    actual = self.tile_bucket.createPolicy(statements, expName, description=expDesc)
+
+    try:
+        assert(expName == actual.policy_name)
+        assert(expDesc == actual.description)
+        assert(settings.IAM_POLICY_PATH == actual.path)
+        assert(actual.default_version is not None)
+
+        # Test that the statements' resource set to this bucket.
+        statements = actual.default_version.document['Statement']
+        bucket_name = TileBucket.getBucketName()
+        arn = 'arn:aws:s3:::{}/*'.format(bucket_name)
+        for stmt in statements:
+            assert(stmt['Resource'] == arn)
+    finally:
+        actual.delete()
+
+
+  def test_createPolicy_with_folder(self):
+    """Test policy creation with a folder"""
+
+    statements = [{
+      'Sid': 'WriteAccess',
+      'Effect': 'Allow',
+      'Action': ['s3:PutObject'] 
+    }]
+
+    expName = 'ndingest_test_tile_bucket_policy'
+    folder = 'some/folder'
+
+    actual = self.tile_bucket.createPolicy(statements, expName, folder)
+
+    try:
+        assert(expName == actual.policy_name)
+        assert(settings.IAM_POLICY_PATH == actual.path)
+        assert(actual.default_version is not None)
+
+        # Test that the statements' resource set to this bucket and folder.
+        statements = actual.default_version.document['Statement']
+        bucket_name = TileBucket.getBucketName()
+        arn = 'arn:aws:s3:::{}/{}/*'.format(bucket_name, folder)
+        for stmt in statements:
+            assert(stmt['Resource'] == arn)
+    finally:
+        actual.delete()
+
+
+  def test_deletePolicy(self):
+    """Test policy deletion"""
+
+    statements = [{
+      'Sid': 'WriteAccess',
+      'Effect': 'Allow',
+      'Action': ['s3:PutObject'] 
+    }]
+
+    expName = 'ndingest_test_tile_bucket_policy'
+    policy = self.tile_bucket.createPolicy(statements, expName)
+    assert(expName == policy.policy_name)
+    self.tile_bucket.deletePolicy(expName)
+    assert(self.tile_bucket.getPolicyArn(expName) is None)
+
+
+if __name__ == '__main__':
+    sut = Test_Upload_Bucket()
+    sut.setup_class()
+    sut.test_createPolicy()
+    sut.teardown_class()

--- a/test/test_uploadqueue.py
+++ b/test/test_uploadqueue.py
@@ -1,4 +1,5 @@
 # Copyright 2014 NeuroData (http://neurodata.io)
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +26,7 @@ serializer = Serializer.load()
 from ndingestproj.ingestproj import IngestProj
 ProjClass = IngestProj.load()
 if settings.PROJECT_NAME == 'Boss':
-    nd_proj = ProjClass('testCol', 'kasthuri11', 'image', 0, 124, 'test.boss.io')
+    nd_proj = ProjClass('testCol', 'kasthuri11', 'image', 0, 123, 'test.boss.io')
 else:
     nd_proj = ProjClass('kasthuri11', 'image', '0')
 
@@ -88,8 +89,11 @@ class Test_UploadQueue():
         assert(expDesc == actual.description)
         assert(settings.IAM_POLICY_PATH == actual.path)
 
-        # Doesn't appear to be a way to programatically test that the
-        # contents of the policy's statements.
+        # Confirm resource set correctly to the upload queue.
+        statements = actual.default_version.document['Statement']
+        arn = self.upload_queue.queue.attributes['QueueArn']
+        for stmt in statements:
+            assert(stmt['Resource'] == arn)
 
     finally:
         actual.delete()


### PR DESCRIPTION
Dead letter queues can be added to cleanup, ingest, and upload queues.
IAM policies can be created for the tile bucket.